### PR TITLE
get_dem composite default edit

### DIFF
--- a/R/get_stac_data.R
+++ b/R/get_stac_data.R
@@ -585,7 +585,7 @@ get_dem <- function(aoi,
                     mask_band = NULL,
                     mask_function = NULL,
                     output_filename = paste0(proceduralnames::make_english_names(1), ".tif"),
-                    composite_function = "median",
+                    composite_function = "max",
                     limit = 999,
                     gdalwarp_options = c(
                       "-r", "bilinear",

--- a/man/get_stac_data.Rd
+++ b/man/get_stac_data.Rd
@@ -134,7 +134,7 @@ get_dem(
   mask_band = NULL,
   mask_function = NULL,
   output_filename = paste0(proceduralnames::make_english_names(1), ".tif"),
-  composite_function = "median",
+  composite_function = "max",
   limit = 999,
   gdalwarp_options = c("-r", "bilinear", "-multi", "-overwrite", "-co",
     "COMPRESS=DEFLATE", "-co", "PREDICTOR=2", "-co", "NUM_THREADS=ALL_CPUS"),


### PR DESCRIPTION
Curious issue which I think is related to where no data exists on the edge of a particular tile see the strange line in the reprex - I know that (for whatever reason), unless explicitly included, the MPC DEM data gives odd no data values, from my experience this needs to be explicity set in the gdal options. But a simpler solution is just to take the max of overlapping cells: 

``` r
library(sf)
#> Linking to GEOS 3.11.1, GDAL 3.6.2, PROJ 9.1.1; sf_use_s2() is TRUE
library(terra)
#> terra 1.7.38
library(rsi)

aoi <- st_bbox(c(
    xmin = 378764.6, ymin = 478279.3,
    xmax = 467780.2, ymax = 532197.8
)) |>
    st_as_sfc() |>
    st_set_crs(29850)

dem_mean <- rast(get_dem(aoi))
dem_max <- rast(get_dem(aoi, composite_function = "max"))

par(mfrow = c(2, 1))
plot(dem_mean, col = hcl.colors(256, "SunsetDark"))
plot(dem_max, col = hcl.colors(256, "SunsetDark"))
```

![](https://i.imgur.com/pAvHEYu.png)<!-- -->

<sup>Created on 2023-09-18 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

This PR just changes the default composite method for `get_dem` to max - nothing crazy. 