### PR TITLE
Only name output bands if it won't error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # rsi (development version)
 
+* `stack_rasters()` will only rename bands if `band_names` is the same length as 
+  the number of bands in the output raster (or missing, or defined by a 
+  function). It will now warn you if these lengths are different. Previously, if 
+  you provided more than the required number of band names, `stack_rasters()` 
+  would silently ignore the extra names, and would error if you provided fewer 
+  names than bands. 
+
 # rsi 0.1.2
 
 * `get_stac_data()` no longer includes `mask_band` in its outputs when 

--- a/R/get_stac_data.R
+++ b/R/get_stac_data.R
@@ -299,7 +299,7 @@ get_stac_data <- function(aoi,
 
   items_urls <- extract_urls(asset_names, items)
   drop_mask_band <- FALSE
-  if (!is.null(mask_band) && !(mask_band %in% names(item_urls))) {
+  if (!is.null(mask_band) && !(mask_band %in% names(items_urls))) {
     items_urls[[mask_band]] <- rstac::assets_url(items, mask_band)
     drop_mask_band <- TRUE
   }

--- a/R/get_stac_data.R
+++ b/R/get_stac_data.R
@@ -298,7 +298,11 @@ get_stac_data <- function(aoi,
   if (is.null(names(asset_names))) names(asset_names) <- asset_names
 
   items_urls <- extract_urls(asset_names, items)
-  if (!is.null(mask_band)) items_urls[[mask_band]] <- rstac::assets_url(items, mask_band)
+  drop_mask_band <- FALSE
+  if (!is.null(mask_band) && !(mask_band %in% names(item_urls))) {
+    items_urls[[mask_band]] <- rstac::assets_url(items, mask_band)
+    drop_mask_band <- TRUE
+  }
 
   download_locations <- data.frame(
     matrix(
@@ -375,6 +379,8 @@ get_stac_data <- function(aoi,
     )
     on.exit(file.remove(unlist(download_results[["final_bands"]])), add = TRUE)
   }
+
+  if (drop_mask_band) items_urls[[mask_band]] <- NULL
 
   mapply(
     function(in_bands, vrt) {

--- a/R/stack_rasters.R
+++ b/R/stack_rasters.R
@@ -238,11 +238,13 @@ stack_rasters <- function(rasters,
     band_def <- grep("VRTRasterBand", vrt)
     vrt <- vrt[seq(band_def[[1]], band_def[[2]])]
     vrt[1] <- gsub("band=\"1\"", paste0("band=\"", band_no, "\""), vrt[1])
-    vrt <- c(
-      vrt[1],
-      paste0("    <Description>", var_names[[band_no]], "</Description>"),
-      vrt[2:length(vrt)]
-    )
+    if (length(intermediate_vrt) == length(var_names)) {
+      vrt <- c(
+        vrt[1],
+        paste0("    <Description>", var_names[[band_no]], "</Description>"),
+        vrt[2:length(vrt)]
+      )
+    }
 
     vrt_bands[[band_no]] <- vrt
 

--- a/tests/testthat/test-stack_rasters.R
+++ b/tests/testthat/test-stack_rasters.R
@@ -143,3 +143,23 @@ test_that("type_and_length checks", {
     error = TRUE
   )
 })
+
+test_that("stack_rasters warns when band names aren't the right length", {
+  expect_warning(
+    stack_rasters(
+      list(system.file("rasters/example_sentinel1.tif", package = "rsi")),
+      tempfile(fileext = ".vrt"),
+      band_names = "VH"
+    ),
+    class = "rsi_band_name_length_mismatch"
+  )
+
+  expect_warning(
+    stack_rasters(
+      list(system.file("rasters/example_sentinel1.tif", package = "rsi")),
+      tempfile(fileext = ".vrt"),
+      band_names = c("VH", "VV", "EXTRA")
+    ),
+    class = "rsi_band_name_length_mismatch"
+  )
+})


### PR DESCRIPTION
This isn't a complete PR, because this needs testing and I'm not sure if this should trigger a warning. But this change means that `get_stac_data()` can download data that's stored as a multi-band file without erroring on this step. Maybe the actual fix is in `get_stac_data()` and we don't pass `band_names` here?

For instance, this change lets you download NAIP:

```r
rsi::get_stac_data(
  aoi,
  start_date = "2019-01-01",
  end_date = "2022-12-31",
  output_filename = "dubuar_naip.tif",
  asset_names = c("image"),
  stac_source = "https://planetarycomputer.microsoft.com/api/stac/v1",
  collection = "naip",
  sign_function = rsi::sign_planetary_computer,
  pixel_x_size = 1,
  pixel_y_size = 1
)
```