### PR TITLE
Survive past failed download when possible

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # rsi (development version)
 
+* `get_stac_data()` no longer fails if downloading an asset fails, but instead
+  returns a raster with all available data. This may still fail when a single 
+  asset fails to download while downloading multiple assets combined within a 
+  single raster; please open an issue if this happens to you! Thanks to 
+  @laurenkwick in #74 (#75).
+
 # rsi 0.2.1
 
 * `calculate_indices()` gains several new arguments:

--- a/R/download.R
+++ b/R/download.R
@@ -128,7 +128,7 @@ rsi_download_rasters <- function(items,
                   "Failed to download {items$features[[which_item]]$id %||% 'UNKNOWN'} from {items$features[[which_item]]$properties$datetime %||% 'UNKNOWN'}" # nolint
                 )
               )
-              download_locations[which_item, ] <- NA
+              download_locations[which_item, ] <<- NA
             }
           )
         },
@@ -138,7 +138,13 @@ rsi_download_rasters <- function(items,
       )
     }
   )
-  as.data.frame(as.list(stats::na.omit(download_locations)))
+  out <- stats::na.omit(download_locations)
+  if (!is.null(na.action(out))) {
+    na_attr <- na.action(out)
+  }
+  out <- as.data.frame(as.list(out))
+  attr(out, "na.action") <- na_attr
+  out
 }
 
 maybe_sign_items <- function(items, sign_function) {

--- a/R/download.R
+++ b/R/download.R
@@ -139,8 +139,8 @@ rsi_download_rasters <- function(items,
     }
   )
   out <- stats::na.omit(download_locations)
-  if (!is.null(na.action(out))) {
-    na_attr <- na.action(out)
+  if (!is.null(stats::na.action(out))) {
+    na_attr <- stats::na.action(out)
   }
   out <- as.data.frame(as.list(out))
   attr(out, "na.action") <- na_attr

--- a/R/download.R
+++ b/R/download.R
@@ -139,9 +139,7 @@ rsi_download_rasters <- function(items,
     }
   )
   out <- stats::na.omit(download_locations)
-  if (!is.null(stats::na.action(out))) {
-    na_attr <- stats::na.action(out)
-  }
+  na_attr <- stats::na.action(out)
   out <- as.data.frame(as.list(out))
   attr(out, "na.action") <- na_attr
   out

--- a/R/get_stac_data.R
+++ b/R/get_stac_data.R
@@ -364,6 +364,9 @@ get_stac_data <- function(aoi,
     gdal_config_options = gdal_config_options,
     ...
   )
+  if (!is.null(na.action(download_results))) {
+    items$features[na.action(download_results)] <- NULL
+  }
   # mask
   if (!is.null(mask_band)) {
     download_results <- rsi_apply_masks(

--- a/R/get_stac_data.R
+++ b/R/get_stac_data.R
@@ -364,8 +364,8 @@ get_stac_data <- function(aoi,
     gdal_config_options = gdal_config_options,
     ...
   )
-  if (!is.null(na.action(download_results))) {
-    items$features[na.action(download_results)] <- NULL
+  if (!is.null(stats::na.action(download_results))) {
+    items$features[stats::na.action(download_results)] <- NULL
   }
   # mask
   if (!is.null(mask_band)) {


### PR DESCRIPTION
Closes #74 

``` r
alos_coll <- "alos-fnf-mosaic"
alos_assets <- "C"
pc_stac_source <- "https://planetarycomputer.microsoft.com/api/stac/v1/"

sf_poly <- sf::read_sf(system.file("shape/nc.shp", package = "sf"))[1, ]

out <- rsi::get_stac_data(
  aoi = sf_poly,
  start_date = "2015-01-01",
  end_date = "2021-12-31",
  asset_names = alos_assets,
  stac_source = pc_stac_source,
  collection = alos_coll,
  sign_function = rsi::sign_planetary_computer,
  download_function = rsi::rsi_download_rasters,
  composite_function = NULL,
  output_filename = tempfile(pattern="fnf_df_", tmpdir=tempdir(), fileext=".tif")
)
#> Warning: Failed to download N37W082_16_FNF from 2016-01-01T00:00:00Z
#> Warning: Failed to download N37W082_15_FNF from 2015-01-01T00:00:00Z

terra::plot(terra::rast(out[[1]]))
```

![](https://i.imgur.com/xv3gcCO.png)<!-- -->

``` r
terra::plot(terra::rast(out[[2]]))
```

![](https://i.imgur.com/tvM54JN.png)<!-- -->

``` r
terra::plot(terra::rast(out[[3]]))
```

![](https://i.imgur.com/d8pTYKU.png)<!-- -->

``` r
terra::plot(terra::rast(out[[4]]))
```

![](https://i.imgur.com/UDTNLMu.png)<!-- -->

<sup>Created on 2024-07-08 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>